### PR TITLE
Fix #3 - game rule to disable thornsprig spawning

### DIFF
--- a/src/main/java/net/mcreator/arsfauna/ArsFaunaMod.java
+++ b/src/main/java/net/mcreator/arsfauna/ArsFaunaMod.java
@@ -16,6 +16,9 @@ import net.minecraftforge.common.MinecraftForge;
 
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.level.GameRules;
+import net.minecraft.world.level.GameRules.BooleanValue;
+import net.minecraft.world.level.GameRules.Key;
 
 import net.mcreator.arsfauna.init.ArsFaunaModTabs;
 import net.mcreator.arsfauna.init.ArsFaunaModParticleTypes;
@@ -36,6 +39,8 @@ public class ArsFaunaMod {
 	public static final Logger LOGGER = LogManager.getLogger(ArsFaunaMod.class);
 	public static final String MODID = "ars_fauna";
 
+	public static Key<BooleanValue> thornsprigSpawning;
+
 	public ArsFaunaMod() {
 		// Start of user code block mod constructor
 		// End of user code block mod constructor
@@ -48,6 +53,8 @@ public class ArsFaunaMod {
 		ArsFaunaModTabs.REGISTRY.register(bus);
 
 		ArsFaunaModParticleTypes.REGISTRY.register(bus);
+
+		thornsprigSpawning = GameRuleFactory.createBoolean("thornsprigSpawning", true, GameRules.Category.MOBS);
 
 		// Start of user code block mod init
 		// End of user code block mod init

--- a/src/main/java/net/mcreator/arsfauna/procedures/ThornsprigSpawnProcedure.java
+++ b/src/main/java/net/mcreator/arsfauna/procedures/ThornsprigSpawnProcedure.java
@@ -18,6 +18,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.core.BlockPos;
 
 import net.mcreator.arsfauna.init.ArsFaunaModEntities;
+import net.mcreator.arsfauna.ArsFaunaMod;
 import org.jetbrains.annotations.NotNull;
 
 @Mod.EventBusSubscriber
@@ -32,7 +33,7 @@ public class ThornsprigSpawnProcedure {
 			return;
 		}
 
-		if (blockstate.is(BlockTags.LOGS)) {
+		if (blockstate.is(BlockTags.LOGS) && event.getWorld().getGameRules().getBoolean(ArsFaunaMod.thornsprigSpawning)) {
 			if (world.getRandom().nextInt(100) == 0) {
 				Entity entityToSpawn = ArsFaunaModEntities.THORNSPRIG.get().spawn(level, BlockPos.containing(x, y, z), MobSpawnType.MOB_SUMMONED);
 				if (entityToSpawn != null) {


### PR DESCRIPTION
Makes `/gamerule thornsprigSpawning` usable to toggle thornsprig spawning. This fixes #3.